### PR TITLE
Fix missing major minor functions in linux collector

### DIFF
--- a/collectors/linux.c
+++ b/collectors/linux.c
@@ -3,6 +3,7 @@
 #include <dirent.h>
 #include <sys/statvfs.h>
 #include <pcre.h>
+#include <sys/sysmacros.h>
 
 #define PROC "/proc"
 #define DEFAULT_TAGS "tags=none"


### PR DESCRIPTION
as of glibc 2.25 sys/types.h no longer provides major and minor
functions for device IDs, they are now provided by the sys/sysmacros
header

Fixes #1 