### PR TITLE
Ignore object files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,6 +36,9 @@
 *.tar.bz2
 /bolo-*.*.*
 
+# object files
+*.o
+
 # generated files
 /bql/lang.c
 /bql/grammar.c


### PR DESCRIPTION
Use gitignore to exclude compiled object files.